### PR TITLE
Potential fix for NPE when initialising daycare

### DIFF
--- a/generations/src/main/java/com/nickimpact/daycare/generations/DaycareGenerations.java
+++ b/generations/src/main/java/com/nickimpact/daycare/generations/DaycareGenerations.java
@@ -43,6 +43,8 @@ import java.util.concurrent.ExecutionException;
 public class DaycareGenerations extends SpongeDaycarePlugin {
 
     private PluginBootstrap bootstrap;
+    
+    private DependencyManager dependencyManager;
 
     @Inject
     @Getter
@@ -83,6 +85,9 @@ public class DaycareGenerations extends SpongeDaycarePlugin {
 
     @Listener
     public void onInit(GameInitializationEvent event) {
+        //must be set before booststrap init, otherwise high risk of NPE
+        this.dependencyManager = new DependencyManager(this);
+        
         bootstrap.init();
         new PokemonTokens().getTokens().forEach(tokens::register);
     }
@@ -121,7 +126,9 @@ public class DaycareGenerations extends SpongeDaycarePlugin {
 
     @Override
     public DependencyManager getDependencyManager() {
-        return SpongeImpactorPlugin.getInstance().getDependencyManager();
+        //this may or may not work and fully depends on whether or not the Impactor plugin is initialized, if it isnt, the plugin crashes
+        //return SpongeImpactorPlugin.getInstance().getDependencyManager();
+        return this.dependencyManager;
     }
 
     @Override


### PR DESCRIPTION
The NPE would occur when the DaycareGenerations.java  calls the getDependency function, which then tries to get to the (impactor) plugin instance for the manager, but if said plugin isnt fully initialised yet, it will cause the daycare to throw a NPE and therefore not work.

The attempt was actually shamelessly stolen from the GTS repo, which also uses the dependcymanager, but instead of grabbing it from another plugin, it creates its own instance, which then works out fine. My attempt here was to do the same with the daycare and therefore preventing it from crashing onInit (example stacktrace: https://mcpaste.io/5d3c035055ef1616).

PS: The code is untested, but in theory, this is how it should work.